### PR TITLE
FIX: test failures with newer SageMath

### DIFF
--- a/stability_conditions/slope.py
+++ b/stability_conditions/slope.py
@@ -31,7 +31,7 @@ import sage.all
 # noinspection PyUnresolvedReferences
 from sage.functions.other import imag_part, real_part
 # noinspection PyUnresolvedReferences
-from sage.symbolic.all import i
+from sage.symbolic.constants import I
 # noinspection PyUnresolvedReferences
 from sage.rings.infinity import infinity
 
@@ -116,4 +116,4 @@ def z(v):
         sage: slope.z(Element([-5, 1/2, 4, 3/2]))
         -5*I - 1/2
     """
-    return -v[1] + i*v[0]
+    return -v[1] + I*v[0]

--- a/stability_conditions/tilt.py
+++ b/stability_conditions/tilt.py
@@ -48,7 +48,7 @@ from sage.rings.rational_field import QQ
 # noinspection PyUnresolvedReferences
 from sage.structure.all import SageObject
 # noinspection PyUnresolvedReferences
-from sage.symbolic.all import i
+from sage.symbolic.constants import I
 
 from .library import previous_farey
 from .slope import delta, mu
@@ -1415,4 +1415,4 @@ def z(v, a, b):
         True
     """
     twisted_ch = ch(v, b)
-    return -twisted_ch[2] + a ** 2 / 2 * twisted_ch[0] + i * twisted_ch[1]
+    return -twisted_ch[2] + a ** 2 / 2 * twisted_ch[0] + I * twisted_ch[1]

--- a/stability_conditions/tilt_two.py
+++ b/stability_conditions/tilt_two.py
@@ -36,7 +36,7 @@ from sage.calculus.functional import expand
 # noinspection PyUnresolvedReferences
 from sage.functions.other import imag_part, real_part
 # noinspection PyUnresolvedReferences
-from sage.symbolic.all import i
+from sage.symbolic.constants import I
 # noinspection PyUnresolvedReferences
 from sage.rings.all import Integer
 # noinspection PyUnresolvedReferences
@@ -202,4 +202,4 @@ def z(v, a, b, s):
     """
     twisted_ch = ch(v, b)
     return (-twisted_ch[3] + (Integer(1)/Integer(6) + s)*a**2*twisted_ch[1]
-            + i*(twisted_ch[2] - a ** 2 / 2 * twisted_ch[0]))
+            + I*(twisted_ch[2] - a ** 2 / 2 * twisted_ch[0]))


### PR DESCRIPTION
Tweak the imports for the imaginary constant as prompted by the deprecation warnings which were failing the doctests.